### PR TITLE
add print statements to scrape.py

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -12,7 +12,7 @@ import pandas as pd
 def get_user_tweets(user: str, n_tweets:int):
 
 
-
+    
     sns_user = st.TwitterUserScraper(user)
     try:
         sns_generator = sns_user.get_items()
@@ -121,25 +121,30 @@ def main(start_user:str, depth:int, num_tweets:int, project_name:str='Project_na
 
     edges = []
     user_info = {}
-
+    
     global n_tweets
     n_tweets = num_tweets
-
+    print('Getting data via snscrape ...')
     result_dict = start_from_user(start_user, depth, n_tweets)
+    print('Searching from user: ...', start_user)
     for user, content in result_dict.items():
         for mentioned in content[1]:
+            print('\tMentioned: ', mentioned)
             edges.append((user,mentioned))
 
 
     edges_set =  set(edges)
     out_edges = []
 
-
+    print('Iterating over edges: ...')
+    i=1
     for edge in edges:
         if (edge[1], edge[0]) in edges_set:
             out_edges.append(edge)
             try:
                 user_info[edge[0]] = result_dict[edge[0]][2]
+                print(i)
+                i+=1
             except KeyError:
                 continue
 
@@ -149,7 +154,7 @@ def main(start_user:str, depth:int, num_tweets:int, project_name:str='Project_na
     user_info_pd = pd.DataFrame.from_dict(user_info, orient = "index")
     user_info_pd.to_csv("user_info.csv")
 
-
+    print('Saving data to local files')
     with open('edge_list.csv', 'w') as handle:
         writer = csv.writer(handle)
         writer.writerows(out_edges)


### PR DESCRIPTION
Added some basic print statements to the scrape.py, all inside main(). 
Note that, when we convert the file to an executable, we can suppress console printouts at setup, so this won't disturb users who don't want to see/use the code-based version.