### PR TITLE
Nlp analysis

### DIFF
--- a/nlp_eda.py
+++ b/nlp_eda.py
@@ -102,7 +102,33 @@ def calculate_and_plot_tfidf(input_dir:Path, output_dir:Path, top_n:int, text_co
                             ngram_range:tuple=(1,2),
                         min_doc_frequency:float=0.01, max_doc_frequency:float = 1.0,
                         smooth_idf:bool=False,):
+    """Pulls up the csv file containing the 
 
+    Args:
+        input_dir (Path): directory containing tweet_text.csv
+        output_dir (Path): directory where we want to output the results (normally the same as input_dir)
+        top_n (int): how many terms do we want displayed
+        text_col_raw (str): name of raw text column
+        tokenizer (optional): Tokenizer for parsing and tokenizing text. Defaults to tokenizer.tokenize.
+        stopwords (list, optional): Stopwords to be discarded. Please modify the generate_stop_words() function
+        to add more stopwords from different languages. Punctuation is also includedd. Defaults to gen_stop_words.
+        ngram_range (tuple, optional): N grams we want to look at. If we want just single tokens, then
+        specify (1,1). Just bigrams : (2,2). Uni-grams, bigrams and trigrams : (1,3). Defaults to (1,2).
+        min_doc_frequency (float, optional): The minimum fraction of tweets we want a term to appear in for it
+        to be included in the final table. Defaults to 0.01 (i.e. 1% of tweets).
+        max_doc_frequency (float, optional): The maximum fraction of tweets we want a term to appear in for it 
+        to be included in the final table - this is useful in case we want to cut-off terms that appear almost
+        everywhere (but remember that the tf-idf score in itself already does some of the work in reducing/eliminating
+        those terms). Defaults to 1.0 (i.e. 100%).
+        smooth_idf (bool, optional): Whether or not to add 1 to the denominator. This is only useful to have as 
+        True when using the tf-idf vectorizer for new, unseen data (e.g. in the case of building a model).
+        The canonical form of the tf-idf formula that most researchers expected, however, does *NOT* have a 1
+        added to the denominator, so it's recommended for descriptive stats that we keep this set to default.
+         Defaults to False.
+
+    Returns:
+        _type_: _description_
+    """    
     fpath = input_dir/ Path('tweet_text.csv')
     df = pd.read_csv(str(fpath))
     df = extract_and_remove_linkable_features(df, text_col_raw)
@@ -111,6 +137,7 @@ def calculate_and_plot_tfidf(input_dir:Path, output_dir:Path, top_n:int, text_co
     return plot_tfidf_dist(tfidf_, output_dir, top_n)
 
 # def clean_df_text(df:pd.DataFrame, text_col_raw:str='tweet_text')->pd.DataFrame:
+
 
 
 

--- a/nlp_eda.py
+++ b/nlp_eda.py
@@ -1,0 +1,58 @@
+import pandas as pd
+import numpy as np
+import os
+
+from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
+import nltk
+import string
+
+from nltk.corpus import stopwords
+from nltk import FreqDist
+from nltk.tokenize import RegexpTokenizer
+from nltk.stem import WordNetLemmatizer, PorterStemmer
+import re
+
+import plotly_express as px
+
+from sklearn.decomposition import LatentDirichletAllocation as LDA
+
+tokenizer = RegexpTokenizer(r'\b[A-Za-z0-9\-]{1,}\b')
+default_tk = tokenizer
+gen_stop_words = list(set(stopwords.words("english")))
+gen_stop_words += list(string.punctuation)
+
+from pathlib import Path
+
+def plot_term_freq_dist(df :pd.DataFrame, output_dir : Path, y_term:str='word', top_n:int=20):
+
+    # top terms, filter out
+    df = df.sort_values('frequency', ascending=False)
+    df = df.iloc[:20]
+
+    fig_follower = px.bar(df, x='frequency',y=y_term,
+                        # color= '#followers', color_continuous_scale= 'deep',
+                labels={
+                    "frequency" : "Frequency",
+                    # "#followers" : "number of followers"
+                    },
+                        )
+    fig_follower.update_traces(hovertemplate='Frequency: %{x}'+'<br>Term: %{y}')
+    fig_follower.update_layout(title_text= f"Most commonly used {y_term}", title_x= 0.5)
+    fig_follower.update_layout({
+    'plot_bgcolor': 'rgba(0, 0, 0, 0)',
+    'paper_bgcolor': 'rgba(0, 0, 0, 0)',
+    })
+    fig_follower.write_html(output_dir/ f"{top_n}_{y_term}_frequency_plot.html")
+
+
+
+def main(input_file:str, output_dir:str):
+
+    return
+
+if __name__=='__main__':
+
+    start_user = sys.argv[0]
+    depth = int(sys.argv[1])
+
+    main()

--- a/nlp_eda.py
+++ b/nlp_eda.py
@@ -45,6 +45,36 @@ def plot_term_freq_dist(df :pd.DataFrame, output_dir : Path, y_term:str='word', 
     fig_follower.write_html(output_dir/ f"{top_n}_{y_term}_frequency_plot.html")
 
 
+#cleaning extract URLs, extract handles
+
+def extract_linkable_features(df:pd.DataFrame, text_col:str='tweet-text')->pd.DataFrame:
+
+
+    df['extracted_twitter_handles'] = df[text_col].apply(lambda x: re.findall('@[a-zA-Z0-9_]{1,16}', x) if isinstance(x,str) else x)
+
+    url_regex_patt = '(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})'
+    df['extracted_URLs'] = df[text_col].apply(lambda x: re.findall(url_regex_patt ,x) if isinstance(x,str) else x)
+
+    df['extracted_hashtags'] = df[text_col].apply(lambda x: re.findall('#[a-zA-Z0-9]{1,140}', x) if isinstance(x,str) else x)
+
+    return df
+
+def remove_linkable_features(df:pd.DataFrame, text_col:str='tweet_text')->pd.DataFrame:
+
+    clean_col = f'clean_{text_col}'
+    df[clean_col] = df[text_col].apply(lambda x: re.subn('@[a-zA-Z0-9_]{1,16}','', x)[0] if isinstance(x,str) else x)
+
+    url_regex_patt = '(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})'
+    df[clean_col] = df[clean_col].apply(lambda x: re.subn(url_regex_patt ,'',x)[0] if isinstance(x,str) else x)
+
+    df[clean_col] = df[clean_col].apply(lambda x: re.subn('#[a-zA-Z0-9]{1,140}','', x)[0] if isinstance(x,str) else x)
+
+    return df
+
+def extract_and_remove_linkable_features(df:pd.DataFrame, text_col:str='tweet_text'):
+
+    return remove_linkable_features(extract_linkable_features(df, text_col))
+
 
 def main(input_file:str, output_dir:str):
 

--- a/nlp_eda.py
+++ b/nlp_eda.py
@@ -102,7 +102,9 @@ def calculate_and_plot_tfidf(input_dir:Path, output_dir:Path, top_n:int, text_co
                             ngram_range:tuple=(1,2),
                         min_doc_frequency:float=0.01, max_doc_frequency:float = 1.0,
                         smooth_idf:bool=False,):
-    """Pulls up the csv file containing the 
+    """Pulls up the csv file containing the tweet texts, cleans, tokenizes and vectorizes
+    the text data and outputs (and returns) a plotly_express graph of the top_n terms by 
+    tf-idf score.
 
     Args:
         input_dir (Path): directory containing tweet_text.csv
@@ -127,18 +129,32 @@ def calculate_and_plot_tfidf(input_dir:Path, output_dir:Path, top_n:int, text_co
          Defaults to False.
 
     Returns:
-        _type_: _description_
+        plot: plotly_express bar plot
     """    
-    fpath = input_dir/ Path('tweet_text.csv')
-    df = pd.read_csv(str(fpath))
-    df = extract_and_remove_linkable_features(df, text_col_raw)
+    df = etl_tweet_text(input_dir)
     text_col_clean = f'clean_{text_col_raw}'
     tfidf_ = get_tfidf_scores(df, text_col_clean, ngram_range, tokenizer, stopwords, min_doc_frequency, max_doc_frequency, smooth_idf)
     return plot_tfidf_dist(tfidf_, output_dir, top_n)
 
-# def clean_df_text(df:pd.DataFrame, text_col_raw:str='tweet_text')->pd.DataFrame:
+def etl_tweet_text(input_dir:Path, text_col_raw:str='tweet_text')->pd.DataFrame:
+    """Get csv file from input_dir tweet_text.csv, extract and clean features such as 
+    URLs, mentions and hashtags into separate columns. Returns copy of data with
+    raw text col and new clean version (same name as raw column with 'clean_' prefix)
 
+    Args:
+        input_dir (Path): directory containing tweet_text.csv
+        output_dir (Path): directory where we want to output the results (normally the same as input_dir)
+        text_col_raw (str): name of raw text column
+        
+    Returns:
+        pd.DataFrame: clean dataframe
+    """    
+    fpath = input_dir/ Path('tweet_text.csv')
+    df = pd.read_csv(str(fpath))
+    df = extract_and_remove_linkable_features(df, text_col_raw)
+    return df
 
+def 
 
 
 def plot_tfidf_dist(data :pd.DataFrame, output_dir : Path,  top_n:int=20):


### PR DESCRIPTION
Created a file for Natural language processing analysis and viz:

- plot_term_freq_dist() can be used to create a plotly_express barplot of raw term frequency across the corpus of tweets
- calculate_and_plot_tfidf() can be used to create a plotly_express barplot of term TF-IDF scores across the corpus of tweets
- etl_transform_visualize_lda_topics() can be used to generate single-page, interactive visualization of LDA topics
